### PR TITLE
EOL replacing fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ikalendar",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ikalendar",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "iKalendar iCal (ics) generator and parser",
   "repository": {
     "type": "git",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -200,10 +200,8 @@ export class Parser implements IParser {
 	}
 
 	private splitLines(iCal: string): string[] {
-		// TODO: Why the f*ck does this have to be like this?
 		return iCal
-			.replace(/\r\n\s/g, '')
-			.replace(/\r/g, '')
+			.replace(/\r?\n\s|\r/g, '')
 			.replace(/\\n/g, ' ')
 			.replace(/  +/g, ' ')
 			.replace(/\\/g, '')


### PR DESCRIPTION
- Replace EOL parsing
   Chaining of `/\r\n\s/g` and `/\r/g` replaced by single `/\r?\n\s|\r/g`
- Bump version patch -> 0.3.1